### PR TITLE
Refactor: Replace DiscountPrice with DiscountPercent

### DIFF
--- a/Pustaksathi.Model/Application/Admin/AdminModel.cs
+++ b/Pustaksathi.Model/Application/Admin/AdminModel.cs
@@ -8,7 +8,7 @@ namespace Pustaksathi.Model.Application.Admin
     {
         public int DiscountId { get; set; }
         public required int BookId { get; set; }
-        public decimal DiscountPrice { get; set; }
+        public decimal DiscountPercent { get; set; }
         public DateTime SaleStartDate { get; set; }
         public DateTime SaleEndDate { get; set; }
         public bool OnSale { get; set; }
@@ -21,7 +21,7 @@ namespace Pustaksathi.Model.Application.Admin
     {
         public required int DiscountId { get; set; }
         public required int BookId { get; set; }
-        public required decimal DiscountPrice { get; set; }
+        public required decimal DiscountPercent { get; set; }
         public required DateTime SaleStartDate { get; set; }
         public required DateTime SaleEndDate { get; set; }
         public bool? OnSale { get; set; } = false;

--- a/Pustaksathi.Model/Application/Books/BooksModel.cs
+++ b/Pustaksathi.Model/Application/Books/BooksModel.cs
@@ -12,7 +12,7 @@ namespace Pustaksathi.Model.Application.Books
         public required decimal Price { get; set; }
         public required int InStock { get; set; }
         public required DateOnly PublishedDate { get; set; }
-        public decimal? DiscountPrice { get; set; }
+        public decimal? DiscountPercent { get; set; }
         public required List<int> LanguageId { get; set; }
         public required List<int> GenreId { get; set; }
         public required List<int> FormatId { get; set; }

--- a/Pustaksathi.Model/Data Models/DataModels.cs
+++ b/Pustaksathi.Model/Data Models/DataModels.cs
@@ -51,7 +51,7 @@ namespace Pustaksathi.Model.DataModels
         public required decimal Price { get; set; }
         public required int InStock { get; set; }
         public required DateOnly PublishedDate { get; set; }
-        public decimal? DiscountPrice { get; set; }
+        public decimal? DiscountPercent { get; set; }
         public required List<int> LanguageId { get; set; }
         public required List<int> GenreId { get; set; }
         public required List<int> FormatId { get; set; }
@@ -160,7 +160,7 @@ namespace Pustaksathi.Model.DataModels
     {
         public int DiscountId { get; set; }
         public required int BookId { get; set; }
-        public decimal DiscountPrice { get; set; }
+        public decimal DiscountPercent { get; set; }
         public DateTime SaleStartDate { get; set; }
         public DateTime SaleEndDate { get; set; }
         public bool OnSale { get; set; }

--- a/Pustaksathi.Services/Application/Admin/AdminService.cs
+++ b/Pustaksathi.Services/Application/Admin/AdminService.cs
@@ -44,7 +44,7 @@ namespace Pustaksathi.Services.Application.Admin
                     await _context.TimeDiscounts.AddAsync(new TimeDiscountDto
                     {
                         BookId = param.BookId,
-                        DiscountPrice = param.DiscountPrice,
+                        DiscountPercent = param.DiscountPercent,
                         SaleStartDate = param.SaleStartDate,
                         SaleEndDate = param.SaleEndDate,
                         OnSale = param.OnSale ?? false
@@ -57,7 +57,7 @@ namespace Pustaksathi.Services.Application.Admin
                     result = await _context.TimeDiscounts
                     .Where(b => b.DiscountId == param.DiscountId)
                     .ExecuteUpdateAsync(b => b
-                                            .SetProperty(b => b.DiscountPrice, param.DiscountPrice)
+                                            .SetProperty(b => b.DiscountPercent, param.DiscountPercent)
                                             .SetProperty(b => b.OnSale, param.OnSale)
                                             .SetProperty(b => b.SaleStartDate, param.SaleStartDate)
                                             .SetProperty(b => b.SaleEndDate, param.SaleEndDate));
@@ -137,7 +137,7 @@ namespace Pustaksathi.Services.Application.Admin
                     {
                         discount.DiscountId,
                         discount.BookId,
-                        discount.DiscountPrice,
+                        discount.DiscountPercent,
                         discount.SaleStartDate,
                         discount.SaleEndDate,
                         discount.OnSale,
@@ -152,7 +152,7 @@ namespace Pustaksathi.Services.Application.Admin
                 {
                     DiscountId = joined.DiscountId,
                     BookId = joined.BookId,
-                    DiscountPrice = joined.DiscountPrice,
+                    DiscountPercent = joined.DiscountPercent,
                     SaleStartDate = joined.SaleStartDate,
                     SaleEndDate = joined.SaleEndDate,
                     OnSale = joined.OnSale,

--- a/Pustaksathi.Services/Application/Books/BooksServices.cs
+++ b/Pustaksathi.Services/Application/Books/BooksServices.cs
@@ -184,7 +184,7 @@ namespace Pustaksathi.Services.Application.Books
                         AuthorId = List.AuthorId,
                         CreatedAt = List.CreatedAt,
                         ModifiedAt = List.ModifiedAt,
-                        DiscountPrice = _context.TimeDiscounts
+                        DiscountPercent = _context.TimeDiscounts
                         .Where(d =>
                             d.BookId == List.BookId
                             && d.OnSale == true
@@ -193,7 +193,7 @@ namespace Pustaksathi.Services.Application.Books
                             && d.SaleEndDate >= DateTime.UtcNow
                         )
                         .OrderByDescending(d => d.SaleStartDate)
-                        .Select(d => (decimal?)d.DiscountPrice)
+                        .Select(d => (decimal?)d.DiscountPercent)
                         .FirstOrDefault()
 
                     })


### PR DESCRIPTION
Replaced `DiscountPrice` with `DiscountPercent` across models, DTOs, and services to standardize discount representation as percentages instead of fixed amounts. Updated properties in `AdminModel.cs`, `BooksModel.cs`, and `DataModels.cs`. Adjusted logic and queries in `AdminService.cs` and `BooksServices.cs` to reflect this change.